### PR TITLE
Fixed typo (vulnerable)

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                 <mark class="hx-flip__placeholder">vulnarable</mark>
                 <mark class="hx-flip__inner">vulnarable</mark>
             </h2>
-            <p>In this sea of sameness, the individual becomes startlingly easy to manipulate. Without the anchor of personal convictions, they drift, <mark class="hx hx-11"><span class="hx__placeholder">vulnarable</span></mark> to whoever steers the crowd's will. It is here, in the pulse of the crowd, where manipulation is not only easy but often goes unnoticed.</p>
+            <p>In this sea of sameness, the individual becomes startlingly easy to manipulate. Without the anchor of personal convictions, they drift, <mark class="hx hx-11"><span class="hx__placeholder">vulnerable</span></mark> to whoever steers the crowd's will. It is here, in the pulse of the crowd, where manipulation is not only easy but often goes unnoticed.</p>
         </div>
         <div class="content__inner">
             <p>The vulnerability of individuals within crowds extends beyond mere <mark class="hx hx-12">manipulation</mark>. Within the collective consciousness, moral responsibility becomes diffuse, diluted among the multitude.</p>


### PR DESCRIPTION
Fixed typo in example 11: vulnarable => vulnerable 